### PR TITLE
Fix mobile viewport scaling and height calculations

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,14 @@ import "@/styles/globals.css";
 import { TRPCReactProvider } from "@/trpc/react";
 import { GeistSans } from "geist/font/sans";
 import { type Metadata } from "next";
+import type { Viewport } from "next";
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+};
 
 export const metadata: Metadata = {
   title: "Keegan Potgieter",
@@ -18,7 +26,7 @@ export default function RootLayout({
     <html lang="en" className={`${GeistSans.variable}`}>
       <body
         className={cn(
-          "h-screen min-h-screen w-screen cursor-default overflow-clip bg-background font-sans text-foreground antialiased",
+          "w-dvh cursor-default overflow-clip bg-background font-sans text-foreground antialiased",
         )}
       >
         <ThemeProvider

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -12,7 +12,7 @@ interface Props {
 const Layout: React.FC<Props> = ({ children, onClick }) => {
   return (
     <div
-      className="relative flex h-screen w-dvw items-center justify-center overflow-hidden overscroll-none bg-background text-xs md:text-base"
+      className="relative flex h-full w-full items-center justify-center overflow-hidden overscroll-none bg-background text-xs md:text-base"
       onClick={onClick}
     >
       <CrypticHover>
@@ -23,7 +23,7 @@ const Layout: React.FC<Props> = ({ children, onClick }) => {
           {children}
         </WindowDisplay>
 
-        <div className="text-muted-foreground/80 absolute z-[1] m-auto h-fit w-fit -translate-y-24 animate-fade-in rounded-md bg-black/10 text-center filter-none backdrop-blur-xl">
+        <div className="absolute z-[1] m-auto h-fit w-fit -translate-y-24 animate-fade-in rounded-md bg-black/10 text-center text-muted-foreground/80 filter-none backdrop-blur-xl">
           <SecretGreeting />
         </div>
       </CrypticHover>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -8,7 +8,7 @@
   font-family: "CascadiaCode";
   src: url(/assets/fonts/CascadiaCode.ttf);
   display: swap;
-  size: 15px;
+  size: 16px;
 }
 
 * {
@@ -19,6 +19,8 @@ body {
   ::-webkit-scrollbar {
     display: none;
   }
+
+  height: calc(100dvh - env(safe-area-inset-bottom));
 
   -webkit-user-select: none; /* Safari */
   -ms-user-select: none; /* IE 10 and IE 11 */


### PR DESCRIPTION
Fixed mobile viewport scaling and height calculations

This PR addresses mobile viewport issues by:
- Disabling user scaling and setting proper viewport constraints
- Using dynamic viewport height (dvh) with safe area insets for better mobile display
- Adjusting font size from 15px to 16px for improved readability
- Refining layout container dimensions and overflow behavior

These changes improve the mobile experience by preventing unwanted scaling and ensuring proper content display across different devices.