### PR TITLE
Add window scroll mask and optimize banner layout

### DIFF
--- a/src/app/terminal.tsx
+++ b/src/app/terminal.tsx
@@ -22,7 +22,7 @@ const TerminalComponent: React.FC<TerminalComponentProps> = ({ inputRef }) => {
 
   return (
     <div className="h-full w-full overflow-hidden rounded-lg p-2">
-      <div ref={containerRef} className="h-full w-full overflow-y-auto">
+      <div ref={containerRef} className="h-full w-full overflow-y-auto pt-2">
         <div className="float-left flex w-full flex-col gap-2 overflow-x-clip">
           <History history={history} />
 

--- a/src/components/ui/extended/window.tsx
+++ b/src/components/ui/extended/window.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { ReactNode } from "react";
 import { useAsciiText, ansiShadow as font } from "react-ascii-text";
 
-function BaseBanner() {
+function Banner() {
   const asciiTextRef = useAsciiText({
     animationCharacters: "▒░█",
     animationCharacterSpacing: 1,
@@ -15,26 +15,6 @@ function BaseBanner() {
     animationSpeed: 30,
     font: font,
     text: ["Keegan Potgieter", "Software Engineer"],
-  });
-
-  return (
-    <pre
-      ref={asciiTextRef as React.MutableRefObject<HTMLPreElement | null>}
-    ></pre>
-  );
-}
-
-function MobileBanner() {
-  const asciiTextRef = useAsciiText({
-    animationCharacters: "▒░█",
-    animationCharacterSpacing: 1,
-    animationDelay: 2000,
-    animationDirection: "vertical",
-    animationInterval: 100,
-    animationLoop: true,
-    animationSpeed: 30,
-    font: font,
-    text: [`Keegan\nPotgieter`, "Software\nEngineer"],
   });
 
   return (
@@ -133,14 +113,16 @@ const WindowDisplay = ({
           { "sm:max-h-0 sm:max-w-0 sm:border-none": minify },
         )}
       >
-        <div className="flex h-fit w-full items-center justify-center pt-2 text-center text-[6px] leading-[0.375rem] md:hidden">
-          <MobileBanner />
+        <div className="flex h-fit w-full items-center justify-center pt-2 text-center text-[4px] leading-[0.25rem] md:hidden">
+          <Banner />
         </div>
 
         <div className="hidden h-fit w-full items-center justify-center pt-2 text-center text-[8px] leading-[0.5rem] md:flex">
-          <BaseBanner />
+          <Banner />
         </div>
-        <div className="overflow-y-auto overscroll-none">{children}</div>
+        <div className="mask relative mt-4 overflow-y-auto overscroll-none">
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/src/styles/themes/index.css
+++ b/src/styles/themes/index.css
@@ -63,6 +63,35 @@
       );
     }
   }
+
+  .mask {
+    position: relative;
+  }
+
+  .mask::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0rem;
+    height: 1rem;
+    background: inherit;
+    z-index: 100;
+    backdrop-filter: blur(5px) brightness(6) contrast(5);
+    -webkit-backdrop-filter: blur(5px) brightness(6) contrast(5);
+    mask-image: linear-gradient(
+      to top,
+      transparent 0%,
+      black 50%,
+      transparent 100%
+    );
+    -webkit-mask-image: linear-gradient(
+      to top,
+      transparent 0%,
+      black 50%,
+      transparent 100%
+    );
+  }
 }
 
 @keyframes border-animate-rotate {

--- a/src/utils/bin/utils.tsx
+++ b/src/utils/bin/utils.tsx
@@ -191,8 +191,8 @@ function Banner() {
 const bannerFn = () => {
   return (
     <BorderAnimate full>
-      <div className="_text-xl flex w-full items-center gap-2 p-0">
-        <div className="pt-1 text-[4px] leading-[0.25rem]">
+      <div className="flex w-full items-center gap-2 p-0">
+        <div className="pt-1 text-[3px] leading-[0.2rem]">
           <Banner />
         </div>
         <div className="h-fit w-fit origin-bottom-right animate-wave text-lg">


### PR DESCRIPTION
Added a scroll mask effect and improved banner sizing across different viewports. The terminal now includes padding at the top, and the ASCII text banner has been consolidated into a single component with adjusted text sizes for better readability on both mobile and desktop displays.