### PR TITLE
Fix terminal scroll behavior and spacing

### DIFF
--- a/src/app/terminal.tsx
+++ b/src/app/terminal.tsx
@@ -22,7 +22,10 @@ const TerminalComponent: React.FC<TerminalComponentProps> = ({ inputRef }) => {
 
   return (
     <div className="h-full w-full overflow-hidden rounded-lg p-2">
-      <div ref={containerRef} className="h-full w-full overflow-y-auto pt-2">
+      <div
+        ref={containerRef}
+        className="h-full w-full overflow-y-auto overscroll-none pt-2"
+      >
         <div className="float-left flex w-full flex-col gap-2 overflow-x-clip">
           <History history={history} />
 

--- a/src/components/history/index.tsx
+++ b/src/components/history/index.tsx
@@ -24,7 +24,7 @@ export const History: React.FC<Props> = ({ history }) => {
             </div>
 
             <Component
-              className="mb-2 whitespace-pre-wrap"
+              className="whitespace-pre-wrap pb-2"
               style={{ lineHeight: "normal" }}
             >
               {entry.output}

--- a/src/components/ui/extended/window.tsx
+++ b/src/components/ui/extended/window.tsx
@@ -120,9 +120,7 @@ const WindowDisplay = ({
         <div className="hidden h-fit w-full items-center justify-center pt-2 text-center text-[7px] leading-[0.5rem] sm:flex">
           <Banner />
         </div>
-        <div className="mask relative my-2 overflow-y-auto overscroll-none">
-          {children}
-        </div>
+        <div className="mask relative overflow-y-clip py-2">{children}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
Fixed terminal scrolling behavior and spacing issues

This PR improves the terminal's scrolling experience and adjusts spacing for better visual consistency:
- Added `overscroll-none` to prevent bounce-scrolling in the terminal
- Replaced margin with padding in history component output
- Adjusted window component overflow handling to prevent nested scrollbars
- Fixed spacing around terminal content

These changes result in smoother scrolling and a more polished terminal interface.