### PR TITLE
Add theme color support and meta tag updates

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
+  themeColor: "#000000",
 };
 
 export const metadata: Metadata = {

--- a/src/components/theme/use-theme.ts
+++ b/src/components/theme/use-theme.ts
@@ -4,6 +4,11 @@ import { themes } from "@/styles/themes";
 import { useTheme as useNextTheme } from "next-themes";
 import React from "react";
 
+const themeColors = {
+  light: "#FFFFFF",
+  dark: "#000000",
+} satisfies Record<(typeof themes)[number], string>;
+
 export const useTheme = () => {
   const { theme, setTheme } = useNextTheme();
 
@@ -24,6 +29,17 @@ export const useTheme = () => {
       }
 
       setTheme(theme);
+
+      const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+
+      if (metaThemeColor) {
+        metaThemeColor.setAttribute(
+          "content",
+          theme
+            ? themeColors[theme as keyof typeof themeColors]
+            : themeColors.dark,
+        );
+      }
 
       return `Theme ${theme} set successfully!`;
     },

--- a/src/styles/themes/index.ts
+++ b/src/styles/themes/index.ts
@@ -1,1 +1,1 @@
-export const themes = ["dark", "light"];
+export const themes = ["dark", "light"] as const;


### PR DESCRIPTION
Added dynamic theme color support for mobile devices

This PR adds theme-color meta tag support, which changes the browser UI color on mobile devices to match the current theme. When switching between light and dark modes, the browser's UI elements (such as the address bar) will now adapt to match the theme colors:

- Light theme: White (#FFFFFF)
- Dark theme: Black (#000000)

The theme color updates automatically when toggling between themes using the theme switcher.