### PR TITLE
Fix cryptic hover component and initial mouse position

### DIFF
--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,4 +1,4 @@
-import { CrypticHover } from "../ui/extended/crypting-hover";
+import { CrypticHover } from "../ui/extended/cryptic-hover";
 import WindowDisplay from "../ui/extended/window";
 import SecretGreeting from "./secret-greeting";
 import React from "react";

--- a/src/components/ui/extended/cryptic-hover.tsx
+++ b/src/components/ui/extended/cryptic-hover.tsx
@@ -12,8 +12,8 @@ export const CrypticHover = ({
   className?: string;
   children?: React.ReactNode;
 }) => {
-  const mouseX = useMotionValue(0);
-  const mouseY = useMotionValue(0);
+  const mouseX = useMotionValue(window.innerWidth / 2);
+  const mouseY = useMotionValue(window.innerHeight / 2);
 
   const [randomString, setRandomString] = useState("");
 
@@ -82,7 +82,7 @@ export function CardPattern({
   return (
     <div className="pointer-events-none z-0">
       <motion.div
-        className="from-primary/50 to-secondary/50 absolute inset-0 bg-gradient-to-r backdrop-blur-2xl transition duration-500 group-hover/card:opacity-100"
+        className="absolute inset-0 bg-gradient-to-r from-primary/50 to-secondary/50 backdrop-blur-2xl transition duration-500 group-hover/card:opacity-100"
         style={style}
       >
         <motion.div


### PR DESCRIPTION
Fixed cryptic hover component initialization and styling

This PR renames the component file from `crypting-hover` to `cryptic-hover` to better reflect its purpose. It also initializes mouse position values to the center of the viewport instead of 0,0 for a better initial state. Additionally, improves class ordering in the gradient background for better readability.

These changes provide a smoother initial render and maintain consistent naming conventions.