### PR TITLE
Fix window mouse initialization and theme type casting

### DIFF
--- a/src/components/ui/extended/cryptic-hover.tsx
+++ b/src/components/ui/extended/cryptic-hover.tsx
@@ -5,6 +5,15 @@ import { type MotionValue, useMotionValue } from "framer-motion";
 import { useMotionTemplate, motion } from "framer-motion";
 import React, { useState, useEffect } from "react";
 
+const getWindowMouseX = () => {
+  if (typeof window !== "undefined") return window.innerWidth / 2;
+  return 0;
+};
+const getWindowMouseY = () => {
+  if (typeof window !== "undefined") return window.innerHeight / 2;
+  return 0;
+};
+
 export const CrypticHover = ({
   className,
   children,
@@ -12,8 +21,8 @@ export const CrypticHover = ({
   className?: string;
   children?: React.ReactNode;
 }) => {
-  const mouseX = useMotionValue(window.innerWidth / 2);
-  const mouseY = useMotionValue(window.innerHeight / 2);
+  const mouseX = useMotionValue(getWindowMouseX());
+  const mouseY = useMotionValue(getWindowMouseY());
 
   const [randomString, setRandomString] = useState("");
 

--- a/src/utils/bin/theme.tsx
+++ b/src/utils/bin/theme.tsx
@@ -52,7 +52,7 @@ export const theme = {
   description: "Set the shell theme",
   _arguments: {
     ls: null,
-    set: themes,
+    set: themes as unknown as string[],
     random: null,
   },
 } satisfies BinFunction<[CallbackFn, ...string[]]>;


### PR DESCRIPTION
Fixed window reference error in CrypticHover component and corrected type casting in theme utility

This PR addresses two issues:
1. Prevents "window is not defined" errors during SSR by adding window availability checks in CrypticHover
2. Fixes TypeScript type casting for themes in the theme utility function

The changes ensure proper server-side rendering compatibility and type safety.